### PR TITLE
Add QTradeX

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 <!-- omit in toc -->
 ### What will you find here?
 
-- [97 libraries and packages](#libraries-and-packages) for research and live trading
+- [98 libraries and packages](#libraries-and-packages) for research and live trading
 - [40+ strategies](#strategies) described by institutionals and academics
 - [55 books](#books) for beginners and professionals
 - [23 videos](#videos) and interviews
@@ -81,7 +81,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 
 # Libraries and packages
 
-*List of **97 libraries and packages** implementing trading bots, backtesters, indicators, pricers, etc. Each library is categorized by its programming language and ordered by descending populatrity (number of stars).*
+*List of **98 libraries and packages** implementing trading bots, backtesters, indicators, pricers, etc. Each library is categorized by its programming language and ordered by descending populatrity (number of stars).*
 
 
 ## Backtesting and Live Trading
@@ -116,6 +116,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 
 | Repository | Description | Stars | Made with |
 |------------|-------------|-------|-----------|
+| [QTradeX](https://github.com/squidKid-deluxe/QTradeX-Algo-Trading-SDK) | A powerful and flexible Python framework for designing, backtesting, optimizing, and deploying algotrading bots | ![GitHub stars](https://badgen.net/github/stars/squidKid-deluxe/QTradeX-Algo-Trading-SDK) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [vectorbt](https://github.com/polakowo/vectorbt) | vectorbt takes a novel approach to backtesting: it operates entirely on pandas and NumPy objects, and is accelerated by Numba to analyze any data at speed and scale. This allows for testing of many thousands of strategies in seconds. | ![GitHub stars](https://badgen.net/github/stars/polakowo/vectorbt) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [pysystemtrade](https://github.com/robcarver17/pysystemtrade) | Systematic Trading in python from book Systematic Trading by Rob Carver | ![GitHub stars](https://badgen.net/github/stars/robcarver17/pysystemtrade) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [bt](https://github.com/pmorissette/bt) | Flexible backtesting for Python based on Algo and Strategy Tree | ![GitHub stars](https://badgen.net/github/stars/pmorissette/bt) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Method and caveats are written up on [the wiki](https://paperswithbacktest.com/w
 
 | Repository | Description | Stars | Made with |
 |------------|-------------|-------|-----------|
+| [QTradeX](https://github.com/squidKid-deluxe/QTradeX-Algo-Trading-SDK) | A powerful and flexible Python framework for designing, backtesting, optimizing, and deploying algotrading bots | ![GitHub stars](https://badgen.net/github/stars/squidKid-deluxe/QTradeX-Algo-Trading-SDK) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [vectorbt](https://github.com/polakowo/vectorbt) | vectorbt takes a novel approach to backtesting: it operates entirely on pandas and NumPy objects, and is accelerated by Numba to analyze any data at speed and scale. This allows for testing of many thousands of strategies in seconds. | ![GitHub stars](https://badgen.net/github/stars/polakowo/vectorbt) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [pysystemtrade](https://github.com/robcarver17/pysystemtrade) | Systematic Trading in python from book Systematic Trading by Rob Carver | ![GitHub stars](https://badgen.net/github/stars/robcarver17/pysystemtrade) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [bt](https://github.com/pmorissette/bt) | Flexible backtesting for Python based on Algo and Strategy Tree | ![GitHub stars](https://badgen.net/github/stars/pmorissette/bt) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |

--- a/README_zh.md
+++ b/README_zh.md
@@ -121,6 +121,7 @@
 
 | 存储库 | 描述 | 明星 | 使用方法 |
 |------------|-------------|-------|-----------|
+| [QTradeX](https://github.com/squidKid-deluxe/QTradeX-Algo-Trading-SDK) | 功能强大且灵活的 Python 框架，用于设计、回测、优化和部署算法交易机器人 | ![GitHub stars](https://badgen.net/github/stars/squidKid-deluxe/QTradeX-Algo-Trading-SDK) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [vectorbt](https://github.com/polakowo/vectorbt) | vectorbt采取了一种新颖的回测方法：它完全在pandas和NumPy对象上运行，并由Numba加速，以速度和规模分析任何数据。这允许在几秒钟内对成千上万的策略进行测试。 | ![GitHub stars](https://badgen.net/github/stars/polakowo/vectorbt) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [pysystemtrade](https://github.com/robcarver17/pysystemtrade) | 罗布-卡弗的《系统交易》一书中的python系统交易 | ![GitHub stars](https://badgen.net/github/stars/robcarver17/pysystemtrade) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [bt](https://github.com/pmorissette/bt) | 基于Algo和策略树的Python的灵活回测 | ![GitHub stars](https://badgen.net/github/stars/pmorissette/bt) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |


### PR DESCRIPTION
Hi,

I'd like to introduce QtradeX – a flexible trading engine that I co-built with @litepresence.

Key Features:
- AI-tuned & open source
- Botscript deployment platform
- Supports Crypto, DeFi, Stocks, Forex, Comex
- Multi-candle backtesting
- Three parameter optimization engines (Quantum PSO, Local search GA, Iterative parametric space expansion)
- Manual optimization GUI
- 50+ backtests per second on modest hardware
- Live trading via CCXT; integration with 100+ exchanges & BitShares DEX
- Data from CCXT, yfinance, cryptocompare, alphavantage, and datafinancereader
- CSV parsing into any candle size, Tulipy indicator integration with 25 custom indicators
- More brokerages, data sources, and indicators coming soon

Resources:
- SDK: https://github.com/squidKid-deluxe/QTradeX-Algo-Trading-SDK
- Bots: https://github.com/squidKid-deluxe/QTradeX-AI-Agents
- Docs: https://deepwiki.com/squidKid-deluxe/QTradeX-Algo-Trading-SDK | https://deepwiki.com/squidKid-deluxe/QTradeX-AI-Agents
- AMA: https://t.me/qtradex_sdk
