### PR TITLE
Add Parsec to Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 | [Investpy](https://github.com/alvarobartt/investpy) | Financial Data Extraction from Investing.com with Python | ![GitHub stars](https://badgen.net/github/stars/alvarobartt/investpy) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Fundamental Analysis Data](https://github.com/JerBouma/FundamentalAnalysis) | Fully-fledged Fundamental Analysis package capable of collecting 20 years of Company Profiles, Financial Statements, Ratios and Stock Data of 20.000+ companies. | ![GitHub stars](https://badgen.net/github/stars/JerBouma/FundamentalAnalysis) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Wallstreet](https://github.com/mcdallas/wallstreet) | Wallstreet: Real time Stock and Option tools | ![GitHub stars](https://badgen.net/github/stars/mcdallas/wallstreet) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
+| [Parsec](https://github.com/parsecular/parsec-mcp) | Prediction market data, execution, and live streams across all major exchanges | ![GitHub stars](https://badgen.net/github/stars/parsecular/parsec-mcp) | ![made-with-rust](https://img.shields.io/badge/Made%20with-Rust-1f425f.svg) |
 
 
 ### Cryptocurrencies


### PR DESCRIPTION
## What
Adds [Parsec](https://parsecapi.com) to the Data Sources section.

## Description
Unified prediction market API with execution across all major exchanges. TypeScript/Python SDKs, MCP server, WebSocket streams. Built in Rust.

- **Website:** https://parsecapi.com
- **Docs:** https://docs.parsecapi.com
- **GitHub:** https://github.com/parsecular/parsec-mcp