### PR TITLE
Add Congressional Stock Brain to Data Sources section

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 | [Investpy](https://github.com/alvarobartt/investpy) | Financial Data Extraction from Investing.com with Python | ![GitHub stars](https://badgen.net/github/stars/alvarobartt/investpy) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Fundamental Analysis Data](https://github.com/JerBouma/FundamentalAnalysis) | Fully-fledged Fundamental Analysis package capable of collecting 20 years of Company Profiles, Financial Statements, Ratios and Stock Data of 20.000+ companies. | ![GitHub stars](https://badgen.net/github/stars/JerBouma/FundamentalAnalysis) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Wallstreet](https://github.com/mcdallas/wallstreet) | Wallstreet: Real time Stock and Option tools | ![GitHub stars](https://badgen.net/github/stars/mcdallas/wallstreet) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
+| [Congressional Stock Brain](https://congressionalstockbrain.com) | AI-powered fintech tool that ingests U.S. STOCK Act disclosures and converts them into machine-scored trade signals for retail investors. Free to use. | - | - |
 
 
 ### Cryptocurrencies


### PR DESCRIPTION
Adds Congressional Stock Brain (congressionalstockbrain.com) to the Data Sources > General section. It is an AI-powered fintech tool that ingests U.S. STOCK Act disclosures (publicly filed lawmaker trades) and converts them into machine-scored trade signals for retail investors. Free to use.