### PR TITLE
Add Adanos Market Sentiment API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 <!-- omit in toc -->
 ### What will you find here?
 
-- [97 libraries and packages](#libraries-and-packages) for research and live trading
+- [98 libraries and packages](#libraries-and-packages) for research and live trading
 - [40+ strategies](#strategies) described by institutionals and academics
 - [55 books](#books) for beginners and professionals
 - [23 videos](#videos) and interviews
@@ -81,7 +81,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 
 # Libraries and packages
 
-*List of **97 libraries and packages** implementing trading bots, backtesters, indicators, pricers, etc. Each library is categorized by its programming language and ordered by descending populatrity (number of stars).*
+*List of **98 libraries and packages** implementing trading bots, backtesters, indicators, pricers, etc. Each library is categorized by its programming language and ordered by descending populatrity (number of stars).*
 
 
 ## Backtesting and Live Trading
@@ -224,6 +224,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 | [Investpy](https://github.com/alvarobartt/investpy) | Financial Data Extraction from Investing.com with Python | ![GitHub stars](https://badgen.net/github/stars/alvarobartt/investpy) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Fundamental Analysis Data](https://github.com/JerBouma/FundamentalAnalysis) | Fully-fledged Fundamental Analysis package capable of collecting 20 years of Company Profiles, Financial Statements, Ratios and Stock Data of 20.000+ companies. | ![GitHub stars](https://badgen.net/github/stars/JerBouma/FundamentalAnalysis) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Wallstreet](https://github.com/mcdallas/wallstreet) | Wallstreet: Real time Stock and Option tools | ![GitHub stars](https://badgen.net/github/stars/mcdallas/wallstreet) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
+| [Adanos Market Sentiment API](https://api.adanos.org/docs/) | Market sentiment API for stock tickers, combining Reddit, X/Twitter, and Polymarket signals with buzz scores and trend analytics. | N/A | API |
 
 
 ### Cryptocurrencies

--- a/README_zh.md
+++ b/README_zh.md
@@ -9,7 +9,7 @@
 <!-- omit in toc -->
 ### 你在这里会发现什么？
 
-- [97个](#库和包)用于研究和实际交易的[库和包](#库和包)
+- [98个](#库和包)用于研究和实际交易的[库和包](#库和包)
 - 机构和学术界描述的[40+项战略](#战略)
 - [55本](#书籍)适合初学者和专业人士的[书籍](#书籍)
 - [23个视频](#视频)和采访
@@ -71,7 +71,7 @@
 
 # 库和包
 
-*97个实现交易机器人、回溯测试器、指标、定价器等的库和包列表。每个库都按其编程语言分类，并按人口降序排列（星星的数量）。*
+*98个实现交易机器人、回溯测试器、指标、定价器等的库和包列表。每个库都按其编程语言分类，并按人口降序排列（星星的数量）。*
 
 
 ## 回溯测试和真实交易
@@ -213,6 +213,7 @@
 | [Investpy](https://github.com/alvarobartt/investpy) | 用Python从Investing.com提取金融数据 | ![GitHub stars](https://badgen.net/github/stars/alvarobartt/investpy) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Fundamental Analysis Data](https://github.com/JerBouma/FundamentalAnalysis) | 完整的基本面分析软件包能够收集20年的公司简介、财务报表、比率和20,000多家公司的股票数据。 | ![GitHub stars](https://badgen.net/github/stars/JerBouma/FundamentalAnalysis) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Wallstreet](https://github.com/mcdallas/wallstreet) | 华尔街。实时股票和期权工具 | ![GitHub stars](https://badgen.net/github/stars/mcdallas/wallstreet) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
+| [Adanos Market Sentiment API](https://api.adanos.org/docs/) | 股票代码市场情绪 API，结合 Reddit、X/Twitter 和 Polymarket 信号，提供 buzz scores 和趋势分析。 | N/A | API |
 
 
 


### PR DESCRIPTION
## Summary
- Add Adanos Market Sentiment API under Data Sources > General.
- Mirror the entry in README_zh.md and increment the displayed library/package count.

## Why
Adanos provides stock ticker market sentiment data from Reddit, X/Twitter, and Polymarket, which fits the list's data-source resources for systematic trading research.

## Validation
- `curl -L -s -o /dev/null -w "%{http_code} %{url_effective}\n" https://api.adanos.org/docs/`
- `git diff --check`
- Markdown table structure check for the affected library/package sections
