### PR TITLE
Add Crypto Motifs blog to Blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,7 @@ A comprehensive list of **55 books** for quantitative traders.
 | [AAA Quants, Tom Starke Blog](http://aaaquants.com/category/blog/) |
 | [AI & Systematic Trading](https://blog.paperswithbacktest.com/)          |
 | [Blackarbs blog](http://www.blackarbs.com/blog/)                   |
+| [Crypto Motifs - Solo Solana Signal Engine + Playbook](https://cryptomotifs.github.io/cipher-starter/) |
 | [Hardikp, Hardik Patel blog](https://www.hardikp.com/)             |
 | [Max Dama on Automated Trading](https://bit.ly/3wVZbh9)            |
 | [Medallion.Club on Systematic Trading (FR)](https://medallion.club/trading-algorithmique-quantitatif-systematique/)            |


### PR DESCRIPTION
Adding a blog/playbook resource under **Blogs**:

**Crypto Motifs** — https://cryptomotifs.github.io/cipher-starter/

A solo-Canadian-dev playbook for building a Solana-native signal engine + autonomous trading bot on $0/mo infrastructure. 12-chapter bundle (~150 pages) covers:
- Universe selection, top-K signal filtering, eighth-Kelly sizing, ATR stops
- Risk rails: 5 circuit breakers, 30-day paper-gate (Sharpe >= 0.8, DD < 12%)
- Security: three-tier wallet architecture ($100 hot / $300 warm / $600 cold)
- MEV sandwich defenses via Jito bundles + oracle gates
- Canadian NI 31-103 compliance path for selling signals as research
- Oracle Cloud Always Free deploy blueprint
- ~1000-tool audit with 30 P0 picks and $0/mo SaaS-stack substitutes

Bundle is public (MIT): https://github.com/cryptomotifs/cipher-starter

Alphabetically slotted between Blackarbs and Hardikp.