### PR TITLE
Add TrendRider Strategy to Cryptocurrencies section

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 | [crypto-crawler-rs](https://github.com/crypto-crawler/crypto-crawler-rs) | Crawl orderbook and trade messages from crypto exchanges | ![GitHub stars](https://badgen.net/github/stars/crypto-crawler/crypto-crawler-rs) | ![made-with-rust](https://img.shields.io/badge/Made%20with-Rust-1f425f.svg) |
 | [Hummingbot](https://github.com/CoinAlpha/hummingbot) | A client for crypto market making | ![GitHub stars](https://badgen.net/github/stars/CoinAlpha/hummingbot) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [cryptotrader-core](https://github.com/monomadic/cryptotrader-core) | Simple to use Crypto Exchange REST API client in rust. | ![GitHub stars](https://badgen.net/github/stars/monomadic/cryptotrader-core) | ![made-with-rust](https://img.shields.io/badge/Made%20with-Rust-1f425f.svg) |
+| [TrendRider Strategy](https://github.com/darkvolg/trendrider-strategy) | Open-source Freqtrade strategy with cascading early-loss-cut exit (65% live WR, MIT). Public live stats at [trendrider.net/live](https://trendrider.net/live). | ![GitHub stars](https://badgen.net/github/stars/darkvolg/trendrider-strategy) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 
 ## Trading bots
 


### PR DESCRIPTION
Hi! Would like to add [TrendRider Strategy](https://github.com/darkvolg/trendrider-strategy) to the **Backtesting and Live Trading → Cryptocurrencies** section.

**What it is**

An open-source Freqtrade strategy that implements a cascading early-loss-cut exit logic (2h@-1.5% → 4h@0% → 8h@+0.5% → 16h@+1% → 24h force). Written in Python, MIT licensed.

**Why it fits here**

- It's a systematic-trading strategy, not just a library — full Freqtrade config, hyperopt setup, and backtest data included.
- Live bot is publicly trading with stats updated every 5 minutes at [trendrider.net/live](https://trendrider.net/live) (~70 trades, ~65% WR as of this PR).
- Includes written post-mortem of how the cascading exit was developed (13 days of breakeven → profitable after the fix).

Placed at the end of the Cryptocurrencies table, alongside Hummingbot / cryptotrader-core.

Happy to adjust wording or re-categorize if you'd prefer a different placement. Thanks!