### PR TITLE
Add bitbank.nz to Data Sources Cryptocurrencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 | [Gekko-Datasets](https://github.com/xFFFFF/Gekko-Datasets) | Gekko trading bot dataset dumps. Download and use history files in SQLite format. | ![GitHub stars](https://badgen.net/github/stars/xFFFFF/Gekko-Datasets) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [CryptoInscriber](https://github.com/Optixal/CryptoInscriber) | A live crypto currency historical trade data blotter. Download live historical trade data from any crypto exchange. | ![GitHub stars](https://badgen.net/github/stars/Optixal/CryptoInscriber) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Crypto Lake](https://github.com/crypto-lake/lake-api) | High frequency order book & trade data for crypto | ![GitHub stars](https://badgen.net/github/stars/crypto-lake/lake-api) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
+| [BitBank](https://bitbank.nz) | AI-powered crypto forecasting and predictions API with machine learning models | - | - |
 
 
 ## Data Science


### PR DESCRIPTION
## Summary
- Adds [BitBank](https://bitbank.nz) to the **Data Sources > Cryptocurrencies** section
- bitbank.nz provides AI-powered crypto forecasting and predictions API with machine learning models
- Follows the existing table format used in the Data Sources sections

## Test plan
- [x] Entry follows the existing table format
- [x] Added to the Cryptocurrencies subsection under Data Sources
- [x] No duplicate entries