### PR TITLE
Add FilingFirehose (SEC EDGAR + body-text-classified 8-Ks) to Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 ## Backtesting and Live Trading
 
 ### General - Event Driven Frameworks
+- [FilingFirehose](https://github.com/jaablon/filingfirehose-python) - SEC EDGAR JSON API with body-text-classified 8-Ks (flags items the filer didn't report — 7.3% of Item 8.01 filings have buried events), Schedule 13D/G with 21+ activist filers tagged automatically, S-3/424B5 ATM offering detection. Free public tier covers past 72h, no API key. Also exposed as MCP server, ChatGPT GPT, Python SDK, GitHub Action.
 
 
 | Repository | Description | Stars | Made with |


### PR DESCRIPTION
Adds FilingFirehose, an SEC EDGAR JSON API I built that parses 8-K body text and flags items the filer didn't report (7.3% of recent Item 8.01 filings have buried 1.05/5.02/etc events). Tags 21+ activist filers on every Schedule 13D/G; detects ATM offerings on S-3/424B5.

For systematic traders: free public tier (no auth, last 72h), paid tier from $29/mo for full historical archive + webhooks. Available as REST API, MCP server (Claude Desktop / Cursor / Windsurf), Python SDK, GitHub Action, and ChatGPT GPT.

- Site: https://filingfirehose.com
- Research: https://filingfirehose.com/research/buried-events
- Free public API: https://filingfirehose.com/v1/public/8k?suspected_buried_only=true