### PR TITLE
Add YIELD INTELLIGENCE — passive income data via MCP to Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 | [Investpy](https://github.com/alvarobartt/investpy) | Financial Data Extraction from Investing.com with Python | ![GitHub stars](https://badgen.net/github/stars/alvarobartt/investpy) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Fundamental Analysis Data](https://github.com/JerBouma/FundamentalAnalysis) | Fully-fledged Fundamental Analysis package capable of collecting 20 years of Company Profiles, Financial Statements, Ratios and Stock Data of 20.000+ companies. | ![GitHub stars](https://badgen.net/github/stars/JerBouma/FundamentalAnalysis) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Wallstreet](https://github.com/mcdallas/wallstreet) | Wallstreet: Real time Stock and Option tools | ![GitHub stars](https://badgen.net/github/stars/mcdallas/wallstreet) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
+| [YIELD INTELLIGENCE](https://github.com/thebrierfox/intuitek-ace) | AI-powered passive income analyzer — live U.S. Treasury rates, dividend ETF screener, REIT yields, and portfolio income optimization via MCP | ![GitHub stars](https://badgen.net/github/stars/thebrierfox/intuitek-ace) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 
 
 ### Cryptocurrencies


### PR DESCRIPTION
Adds [YIELD INTELLIGENCE](https://github.com/thebrierfox/intuitek-ace) to the Data Sources > General section.

YIELD INTELLIGENCE is a free hosted MCP server for passive income data:
- Live U.S. Treasury rates (T-bills, notes, 30-year bonds)
- Dividend ETF screener (VYM, SCHD, JEPI and similar)
- REIT yield analysis
- Portfolio optimizer for income-weighted allocations

No API key required. Complements existing data sources like yfinance and OpenBB.