### PR TITLE
Add The Stall — 210 pay-per-call MCP market data tools (x402, USDC, v4.64.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 | [Investpy](https://github.com/alvarobartt/investpy) | Financial Data Extraction from Investing.com with Python | ![GitHub stars](https://badgen.net/github/stars/alvarobartt/investpy) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Fundamental Analysis Data](https://github.com/JerBouma/FundamentalAnalysis) | Fully-fledged Fundamental Analysis package capable of collecting 20 years of Company Profiles, Financial Statements, Ratios and Stock Data of 20.000+ companies. | ![GitHub stars](https://badgen.net/github/stars/JerBouma/FundamentalAnalysis) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Wallstreet](https://github.com/mcdallas/wallstreet) | Wallstreet: Real time Stock and Option tools | ![GitHub stars](https://badgen.net/github/stars/mcdallas/wallstreet) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
+| [The Stall](https://github.com/thebrierfox/the-stall) | 173 pay-per-call MCP tools: US stocks, crypto, DeFi, Polymarket prediction markets, macro data, and sanctions screening. USDC on Base. No API key required. | ![GitHub stars](https://badgen.net/github/stars/thebrierfox/the-stall) | ![made-with-javascript](https://img.shields.io/badge/Made%20with-JavaScript-1f425f.svg) |
 
 
 ### Cryptocurrencies


### PR DESCRIPTION
## What

Adds [The Stall](https://github.com/thebrierfox/the-stall) to the **Data Sources > General** section.

## What it is

The Stall is a live MCP server exposing 210 pay-per-call data capabilities useful for systematic trading research:

- **US equities**: real-time prices, analyst ratings, earnings, SEC filings, options chains, short interest
- **Crypto & DeFi**: prices across CEX/DEX, token security scoring, on-chain intelligence
- **Prediction markets**: Polymarket data — prices, positions, volume, resolution history  
- **Macro**: FRED economic indicators, PMI, CPI, rates
- **Compliance**: OFAC/SDN sanctions screening, address security

Payment: USDC on Base mainnet via x402 protocol. No API key, no subscription — agents pay per call.

## Links
- GitHub: https://github.com/thebrierfox/the-stall
- Live: https://the-stall.intuitek.ai
- MCP endpoint: https://the-stall.intuitek.ai/mcp
- Smithery: https://smithery.ai/server/thebrierfox/the-stall
