### PR TITLE
Add Wickra to Indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Method and caveats are written up on [the wiki](https://paperswithbacktest.com/w
 | [pandas-ta](https://github.com/twopirllc/pandas-ta) `no longer available` | Pandas Technical Analysis (Pandas TA) is an easy to use library that leverages the Pandas package with more than 130 Indicators and Utility functions and more than 60 TA Lib Candlestick Patterns | ![GitHub stars](https://badgen.net/github/stars/twopirllc/pandas-ta) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [finta](https://github.com/peerchemist/finta) `archived` | Common financial technical indicators implemented in Pandas | ![GitHub stars](https://badgen.net/github/stars/peerchemist/finta) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [ta-rust](https://github.com/greyblake/ta-rs) `dormant since 2024-07` | Technical analysis library for Rust language | ![GitHub stars](https://badgen.net/github/stars/greyblake/ta-rs) | ![made-with-rust](https://img.shields.io/badge/Made%20with-Rust-1f425f.svg) |
+| [wickra](https://github.com/wickra-lib/wickra) | Streaming-first technical-analysis library with a Rust core and native Python/Node/WASM bindings plus a C ABI (C, C++, C#/.NET, Go, Java, R); 514 O(1)-per-tick indicators across 24 families, bit-exact batch and streaming | ![GitHub stars](https://badgen.net/github/stars/wickra-lib/wickra) | ![made-with-rust](https://img.shields.io/badge/Made%20with-Rust-1f425f.svg) |
 
 ### Metrics computation
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -167,6 +167,7 @@
 | [pandas-ta](https://github.com/twopirllc/pandas-ta) | 潘达斯技术分析（Pandas TA）是一个易于使用的库，它利用潘达斯软件包的130多个指标和实用功能以及60多个TA Lib蜡烛图。 | ![GitHub stars](https://badgen.net/github/stars/twopirllc/pandas-ta) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [finta](https://github.com/peerchemist/finta) | 在Pandas中实施的共同财务技术指标 | ![GitHub stars](https://badgen.net/github/stars/peerchemist/finta) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [ta-rust](https://github.com/greyblake/ta-rs) | Rust语言的技术分析库 | ![GitHub stars](https://badgen.net/github/stars/greyblake/ta-rs) | ![made-with-rust](https://img.shields.io/badge/Made%20with-Rust-1f425f.svg) |
+| [wickra](https://github.com/wickra-lib/wickra) | 以流式处理为先的技术分析库，Rust 内核，提供 Python/Node/WASM 原生绑定和 C ABI（C、C++、C#/.NET、Go、Java、R）；涵盖 24 个类别的 514 个每次 tick 为 O(1) 的指标，批处理与流式结果按位一致 | ![GitHub stars](https://badgen.net/github/stars/wickra-lib/wickra) | ![made-with-rust](https://img.shields.io/badge/Made%20with-Rust-1f425f.svg) |
 
 ### 度量衡计算
 


### PR DESCRIPTION
Adds Wickra to the Analytics -> Indicators table (next to ta-lib, pandas-ta, finta, ta-rust, go-tart).

Wickra is an open-source (MIT OR Apache-2.0) multi-language technical-analysis library: a Rust core with native Python, Node.js and WebAssembly bindings plus a C ABI for C, C++, C#/.NET, Go, Java and R. Every indicator updates in O(1) per data point, so backtests and live trading share one implementation.

Highlights:
- 514 indicators across 24 families - far beyond the ~150 of TA-Lib, including microstructure, order-flow, market profile and Ehlers cycles.
- batch == streaming is bit-exact, fuzzed and 100%-line-covered for all 514.
- 11-56x faster than the only other incremental peer in streaming.
- No system dependencies; one-line install on macOS, Linux and Windows. MIT OR Apache-2.0.

Placed by descending stars; Made with = Rust (the core). Published on crates.io, PyPI, npm, NuGet, Maven Central, Go modules and r-universe.
Repo: https://github.com/wickra-lib/wickra
