### PR TITLE
Add mt5-trading-mcp to Broker APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 | [Ib_insync](https://github.com/erdewit/ib_insync) | Python sync/async framework for Interactive Brokers. | ![GitHub stars](https://badgen.net/github/stars/erdewit/ib_insync) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Coinnect](https://github.com/hugues31/coinnect) | Coinnect is a Rust library aiming to provide a complete access to main crypto currencies exchanges via REST API. | ![GitHub stars](https://badgen.net/github/stars/hugues31/coinnect) | ![made-with-rust](https://img.shields.io/badge/Made%20with-Rust-1f425f.svg) |
 | [PENDAX](https://github.com/CompendiumFi/PENDAX-SDK) | Javascript SDK for Trading, Data, and Websockets for FTX, FTXUS, OKX, Bybit, & More. | ![GitHub stars](https://badgen.net/github/stars/CompendiumFi/PENDAX-SDK) | ![made-with-javascript](https://img.shields.io/badge/Made%20with-Javascript-1f425f.svg) |
+| [mt5-trading-mcp](https://github.com/vincentwongso/mt5-trading-mcp) | Let an AI agent read and trade a MetaTrader 5 account over MCP (Model Context Protocol), behind a configurable human-approval gate — preflight checks, idempotency, and an append-only audit log. | ![GitHub stars](https://badgen.net/github/stars/vincentwongso/mt5-trading-mcp) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 
 
 ## Data Sources


### PR DESCRIPTION
Adds **mt5-trading-mcp** to the **Broker APIs** section.

It lets an AI agent read and trade a MetaTrader 5 account over MCP (Model Context
Protocol). Unlike a plain broker SDK, every mutating order routes through
preflight checks → an opt-in human-consent gate → idempotency → an append-only
audit log, with an explicit threat model — useful for putting a human in the
loop on systematic/agent-driven execution against MT5.

- Repo: https://github.com/vincentwongso/mt5-trading-mcp
- Python, `pip install mt5-trading-mcp`; Windows (native) + Linux (Docker)
- Listed on the official MCP Registry (`io.github.vincentwongso/mt5-trading-mcp`)

Entry follows the existing Broker APIs table format (Repository | Description |
Stars | Made with).
