### PR TITLE
Add Alphamolt

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 | [quanttrader](https://github.com/letianzj/quanttrader) | Backtest and live trading in Python. Event based. Similar to backtesting.py. | ![GitHub stars](https://badgen.net/github/stars/letianzj/quanttrader) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [gobacktest](https://github.com/gobacktest/gobacktest) | A Go implementation of event-driven backtesting framework | ![GitHub stars](https://badgen.net/github/stars/gobacktest/gobacktest) | ![made-with-go](https://img.shields.io/badge/Made%20with-Go-1f425f.svg) |
 | [FlashFunk](https://github.com/HFQR/FlashFunk) | High Performance Runtime in Rust | ![GitHub stars](https://badgen.net/github/stars/HFQR/FlashFunk) | ![made-with-rust](https://img.shields.io/badge/Made%20with-Rust-1f425f.svg) |
-| [alphamolt](https://github.com/tobyrowland/update_ai_analysis) | An arena where AI/LLM agents run stock portfolios and compete on a public leaderboard. Strategies are pluggable Python functions (`rebalance(ctx)`) with pure, no-keys-testable decision cores; ships example agents including a 200-week-MA dip buyer, LLM conviction buyers, and a Congress-trade mirror. | ![GitHub stars](https://badgen.net/github/stars/tobyrowland/update_ai_analysis) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 
 
 ### General - Vector Based Frameworks
@@ -149,6 +148,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 | [R2 Bitcoin Arbitrager](https://github.com/bitrinjani/r2) | R2 Bitcoin Arbitrager is an automatic arbitrage trading system powered by Node.js + TypeScript | ![GitHub stars](https://badgen.net/github/stars/bitrinjani/r2) | ![made-with-typescript](https://img.shields.io/badge/Made%20with-TypeScript-1f425f.svg) |
 | [analyzingalpha](https://github.com/leosmigel/analyzingalpha) | Implementation of simple strategies | ![GitHub stars](https://badgen.net/github/stars/leosmigel/analyzingalpha) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [PyTrendFollow](https://github.com/chrism2671/PyTrendFollow) | PyTrendFollow - systematic futures trading using trend following | ![GitHub stars](https://badgen.net/github/stars/chrism2671/PyTrendFollow) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
+| [alphamolt](https://github.com/tobyrowland/update_ai_analysis) | An arena where AI/LLM agents run stock portfolios and compete on a public leaderboard. Strategies are pluggable Python functions (`rebalance(ctx)`) with pure, no-keys-testable decision cores; ships example agents including a 200-week-MA dip buyer, LLM conviction buyers, and a Congress-trade mirror. | ![GitHub stars](https://badgen.net/github/stars/tobyrowland/update_ai_analysis) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 
 ## Analytics
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 | [quanttrader](https://github.com/letianzj/quanttrader) | Backtest and live trading in Python. Event based. Similar to backtesting.py. | ![GitHub stars](https://badgen.net/github/stars/letianzj/quanttrader) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [gobacktest](https://github.com/gobacktest/gobacktest) | A Go implementation of event-driven backtesting framework | ![GitHub stars](https://badgen.net/github/stars/gobacktest/gobacktest) | ![made-with-go](https://img.shields.io/badge/Made%20with-Go-1f425f.svg) |
 | [FlashFunk](https://github.com/HFQR/FlashFunk) | High Performance Runtime in Rust | ![GitHub stars](https://badgen.net/github/stars/HFQR/FlashFunk) | ![made-with-rust](https://img.shields.io/badge/Made%20with-Rust-1f425f.svg) |
+| [alphamolt](https://github.com/tobyrowland/update_ai_analysis) | An arena where AI/LLM agents run stock portfolios and compete on a public leaderboard. Strategies are pluggable Python functions (`rebalance(ctx)`) with pure, no-keys-testable decision cores; ships example agents including a 200-week-MA dip buyer, LLM conviction buyers, and a Congress-trade mirror. | ![GitHub stars](https://badgen.net/github/stars/tobyrowland/update_ai_analysis) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 
 
 ### General - Vector Based Frameworks


### PR DESCRIPTION
Adds alphamolt — an open-source arena where AI/LLM agents run stock portfolios and compete on a public leaderboard. Pluggable Python strategies, pure cores testable with no keys.