### PR TITLE
Add FillBench to Data Sources > Cryptocurrencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 | [crypto-crawler-rs](https://github.com/crypto-crawler/crypto-crawler-rs) | Crawl orderbook and trade messages from crypto exchanges | ![GitHub stars](https://badgen.net/github/stars/crypto-crawler/crypto-crawler-rs) | ![made-with-rust](https://img.shields.io/badge/Made%20with-Rust-1f425f.svg) |
 | [Hummingbot](https://github.com/CoinAlpha/hummingbot) | A client for crypto market making | ![GitHub stars](https://badgen.net/github/stars/CoinAlpha/hummingbot) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [cryptotrader-core](https://github.com/monomadic/cryptotrader-core) | Simple to use Crypto Exchange REST API client in rust. | ![GitHub stars](https://badgen.net/github/stars/monomadic/cryptotrader-core) | ![made-with-rust](https://img.shields.io/badge/Made%20with-Rust-1f425f.svg) |
+| [FillBench](https://github.com/sircharli3/fillbench-data) | Reproducible crypto exchange REST API latency benchmarks (p50/p95/p99 and TLS connect time), updated automatically. Live site with charts and methodology: [fillbench.com](https://fillbench.com/exchange-api-latency) | ![GitHub stars](https://badgen.net/github/stars/sircharli3/fillbench-data) | ![made-with-json](https://img.shields.io/badge/Made%20with-JSON-1f425f.svg) |
 
 ## Trading bots
 


### PR DESCRIPTION
### What
Adds FillBench to Data Sources > Cryptocurrencies.

### What it is
FillBench publishes reproducible crypto exchange REST API latency benchmarks (p50/p95/p99 and TLS connect time), measured from a fixed US East server and updated automatically. The raw data is open (CC BY 4.0) as machine-readable JSON, with a documented method and a daily time series.

- Open data repo: https://github.com/sircharli3/fillbench-data
- Live site (charts + methodology): https://fillbench.com/exchange-api-latency

Happy to adjust wording or placement to match the list's conventions.