### PR TITLE
Add BDE Score™ - AI-Powered Multi-Market Stock Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 | [Investpy](https://github.com/alvarobartt/investpy) | Financial Data Extraction from Investing.com with Python | ![GitHub stars](https://badgen.net/github/stars/alvarobartt/investpy) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Fundamental Analysis Data](https://github.com/JerBouma/FundamentalAnalysis) | Fully-fledged Fundamental Analysis package capable of collecting 20 years of Company Profiles, Financial Statements, Ratios and Stock Data of 20.000+ companies. | ![GitHub stars](https://badgen.net/github/stars/JerBouma/FundamentalAnalysis) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Wallstreet](https://github.com/mcdallas/wallstreet) | Wallstreet: Real time Stock and Option tools | ![GitHub stars](https://badgen.net/github/stars/mcdallas/wallstreet) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
+| [BDE Score](https://github.com/hbhqq9/bde-score) | AI-powered multi-market stock analysis with transparent BDE scoring across 73 stocks (US/HK/A-share). EU AI Act Art.50 compliant. MIT license. | ![GitHub stars](https://badgen.net/github/stars/hbhqq9/bde-score) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 
 
 ### Cryptocurrencies


### PR DESCRIPTION
## Add BDE Score™ to Machine Learning section

Adding [BDE Score™](https://github.com/hbhqq9/bde-score) to the **Machine Learning** section.

### About BDE Score™
- **AI-Powered Multi-Market Stock Analysis** — transparent multi-factor scoring for 73 stocks across US, HK, and A-share markets
- **EU AI Act Art.50 compliant**
- **Live Demo**: https://rebel-north-intermediate-roof.trycloudflare.com
- **License**: MIT
- **Topics**: stock-analysis, quantitative-finance, ai-finance, eu-ai-act, multi-market

Thank you for maintaining this awesome list! 🙏