### PR TITLE
Add AgentServices — x402-paid crypto/market data APIs with MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 | [Gekko-Datasets](https://github.com/xFFFFF/Gekko-Datasets) | Gekko trading bot dataset dumps. Download and use history files in SQLite format. | ![GitHub stars](https://badgen.net/github/stars/xFFFFF/Gekko-Datasets) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [CryptoInscriber](https://github.com/Optixal/CryptoInscriber) | A live crypto currency historical trade data blotter. Download live historical trade data from any crypto exchange. | ![GitHub stars](https://badgen.net/github/stars/Optixal/CryptoInscriber) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Crypto Lake](https://github.com/crypto-lake/lake-api) | High frequency order book & trade data for crypto | ![GitHub stars](https://badgen.net/github/stars/crypto-lake/lake-api) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
+| [AgentServices](https://agentservices.to) | 54 services, 41 x402-paid crypto/market data endpoints with MCP integration and on-chain USDC settlement | ![GitHub stars](https://badgen.net/github/stars/vbkotecha/agentservices) | ![made-with-javascript](https://img.shields.io/badge/Made%20with-JavaScript-1f425f.svg) |
 
 
 ## Data Science


### PR DESCRIPTION
## What

Added **[AgentServices](https://agentservices.to)** to the **Cryptocurrencies** subsection under Data Sources.

## Why

AgentServices is a production API platform for crypto and market data, uniquely positioned for AI agent consumption:

- **54 services, 97 API paths** covering FX rates, token prices, onchain analytics, market intelligence
- **41 x402-paid endpoints** — on-chain USDC micropayments on Base (no API keys required)
- **37 MCP tools** (Model Context Protocol) — agents discover and call endpoints natively
- **Official MCP Registry**: `to.agentservices/agentservices` (v5.3.0)

This fits alongside existing crypto data sources like Cryptofeed and Crypto Lake, with the differentiator of being agent-native (MCP + x402 payment protocol).

## Verification

All endpoints verified healthy:
- Homepage: https://agentservices.to (200 OK)
- API: https://api.agentservices.to (200 OK)
- MCP: https://api.agentservices.to/mcp (AgentServices v5.3.0)
- x402: https://api.agentservices.to/.well-known/x402 (200 OK)