### PR TITLE
Add AI in Trading guide to Blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,7 @@ A comprehensive list of **55 books** for quantitative traders.
 | [Quantsportal, Jacques Joubert's Blog](http://www.quantsportal.com/blog-page/) |
 | [Quantstart - Machine Learning for Trading articles](https://www.quantstart.com/articles) |
 | [RobotWealth, Kris Longmore Blog](https://robotwealth.com/blog/) |
+| [AI in Trading: What It Actually Does](https://arapov.trade/en/freestudying/ai-in-trading) |
 
 
 # Courses


### PR DESCRIPTION
Adding a free resource on the practical role of AI in trading to complement the quant/systematic trading blogs in this section.