### PR TITLE
Add ml-quant-trading to vector-based frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Method and caveats are written up on [the wiki](https://paperswithbacktest.com/w
 | [vectorbt](https://github.com/polakowo/vectorbt) | vectorbt takes a novel approach to backtesting: it operates entirely on pandas and NumPy objects, and is accelerated by Numba to analyze any data at speed and scale. This allows for testing of many thousands of strategies in seconds. | ![GitHub stars](https://badgen.net/github/stars/polakowo/vectorbt) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [pysystemtrade](https://github.com/robcarver17/pysystemtrade) | Systematic Trading in python from book Systematic Trading by Rob Carver | ![GitHub stars](https://badgen.net/github/stars/robcarver17/pysystemtrade) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [bt](https://github.com/pmorissette/bt) | Flexible backtesting for Python based on Algo and Strategy Tree | ![GitHub stars](https://badgen.net/github/stars/pmorissette/bt) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
+| [ml-quant-trading](https://github.com/initial-d/ml-quant-trading) | PyTorch research stack for ML multi-factor trading with 213 factors, bias correction, portfolio optimization, vectorized backtesting, and public validation reports | ![GitHub stars](https://badgen.net/github/stars/initial-d/ml-quant-trading) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 
 
 ### Cryptocurrencies

--- a/README_zh.md
+++ b/README_zh.md
@@ -124,6 +124,7 @@
 | [vectorbt](https://github.com/polakowo/vectorbt) | vectorbt采取了一种新颖的回测方法：它完全在pandas和NumPy对象上运行，并由Numba加速，以速度和规模分析任何数据。这允许在几秒钟内对成千上万的策略进行测试。 | ![GitHub stars](https://badgen.net/github/stars/polakowo/vectorbt) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [pysystemtrade](https://github.com/robcarver17/pysystemtrade) | 罗布-卡弗的《系统交易》一书中的python系统交易 | ![GitHub stars](https://badgen.net/github/stars/robcarver17/pysystemtrade) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [bt](https://github.com/pmorissette/bt) | 基于Algo和策略树的Python的灵活回测 | ![GitHub stars](https://badgen.net/github/stars/pmorissette/bt) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
+| [ml-quant-trading](https://github.com/initial-d/ml-quant-trading) | 面向机器学习多因子交易的 PyTorch 研究栈：213 个因子、偏差修正、组合优化、向量化回测，并附公开的验证报告 | ![GitHub stars](https://badgen.net/github/stars/initial-d/ml-quant-trading) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 
 
 ### 加密货币


### PR DESCRIPTION
Adds `ml-quant-trading` to the vector-based frameworks section.

Why it fits this list:

- Python/PyTorch research stack for systematic multi-factor experiments
- vectorized backtesting and portfolio optimization workflow
- 213 documented factor dimensions
- public validation reports and reproducibility notes in the v0.2.0 release
- research/education focused; not a trading-signal claim

Release: https://github.com/initial-d/ml-quant-trading/releases/tag/v0.2.0
Paper: https://arxiv.org/abs/2507.07107