### PR TITLE
Avoid relying on dictionary insertion order when extracting ESG tickers

### DIFF
--- a/static/strategies/esg-factor-momentum-strategy.py
+++ b/static/strategies/esg-factor-momentum-strategy.py
@@ -131,8 +131,9 @@ class ESGFactorMomentumStrategy(QCAlgorithm):
         if 'ESG' in data and data['ESG']:
             # Store universe tickers.
             if len(self.tickers) == 0:
-                # TODO '_typename' in storage dictionary?
-                self.tickers = [x.Key for x in self.esg_data.GetLastData().GetStorageDictionary()][:-1]
+                # "__typename" is framework metadata, not a ticker symbol.
+                storage_dict = self.esg_data.GetLastData().GetStorageDictionary()
+                self.tickers = [x.Key for x in storage_dict if x.Key != "__typename"]
         
             # Store history for every ticker.
             for ticker in self.tickers:


### PR DESCRIPTION
## Summary

This PR replaces the insertion-order dependent slicing used when extracting ticker symbols from `GetStorageDictionary()`.

Previously, the implementation relied on removing the last element (`[:-1]`), assuming `__typename` would always be the final entry in the storage dictionary.

This change explicitly filters the `__typename` metadata key instead, making the intent clearer and avoiding reliance on dictionary insertion order.

## Changes

- Replace `[:-1]` with explicit filtering of `__typename`
- Add a comment explaining why the metadata key is excluded

## Why

The previous implementation depended on dictionary insertion order. Explicitly filtering the framework metadata preserves the existing behavior while making the code more robust and easier to understand.

Related to #78