### PR TITLE
Add midas-core to event-driven frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 | [quanttrader](https://github.com/letianzj/quanttrader) | Backtest and live trading in Python. Event based. Similar to backtesting.py. | ![GitHub stars](https://badgen.net/github/stars/letianzj/quanttrader) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [gobacktest](https://github.com/gobacktest/gobacktest) | A Go implementation of event-driven backtesting framework | ![GitHub stars](https://badgen.net/github/stars/gobacktest/gobacktest) | ![made-with-go](https://img.shields.io/badge/Made%20with-Go-1f425f.svg) |
 | [FlashFunk](https://github.com/HFQR/FlashFunk) | High Performance Runtime in Rust | ![GitHub stars](https://badgen.net/github/stars/HFQR/FlashFunk) | ![made-with-rust](https://img.shields.io/badge/Made%20with-Rust-1f425f.svg) |
+| [midas-core](https://github.com/w2ur/midas-core) | Multi-agent paper-trading framework where LLM agents author orders and a separate broker process enforces safety rails at fill time | ![GitHub stars](https://badgen.net/github/stars/w2ur/midas-core) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 
 
 ### General - Vector Based Frameworks


### PR DESCRIPTION
Adds [midas-core](https://github.com/w2ur/midas-core), an open-source (MIT, Python 3.12+) multi-agent paper-trading framework, to *General - Event Driven Frameworks*.

It is event-driven in the Brain/Hands sense: agents author orders to an append-only outbox and hold no credentials; a separate broker process reads that outbox and adjudicates every order at fill time against fifteen fixed reason codes (order notional cap, per-day order cap, universe allowlist, cash and position checks, drawdown halt, and others). Conditional orders are deferred to a watcher process that applies the same order-level rails when the price condition fires.

Reproducibility is a design goal: pinned lockfile, prices and index universes committed to git, no outbound HTTP during a trading session, and every fill stamped with the git commit it executed against.

Paper trading only — it never executes against real broker credentials, pools funds, or gives advice. Also on PyPI: https://pypi.org/project/midas-core/

The row matches the existing table format (4 columns, badgen stars badge, made-with-Python badge).