### PR TITLE
Add pwb-toolbox to Data Sources, in all three languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 <!-- omit in toc -->
 ### What will you find here?
 
-- [111 libraries and packages](#libraries-and-packages) for research and live trading, with dead and dormant projects flagged
+- [112 libraries and packages](#libraries-and-packages) for research and live trading, with dead and dormant projects flagged
 - [Strategies](#strategies) from published papers, with the Sharpe ratio each one produced when it was coded and run
 - [55 books](#books) for beginners and professionals
 - [22 videos](#videos) and interviews
@@ -100,7 +100,7 @@ Method and caveats are written up on [the wiki](https://paperswithbacktest.com/w
 
 # Libraries and packages
 
-*List of **111 libraries and packages** implementing trading bots, backtesters, indicators, pricers, etc. Each library is categorized by its programming language and ordered by descending populatrity (number of stars).*
+*List of **112 libraries and packages** implementing trading bots, backtesters, indicators, pricers, etc. Each library is categorized by its programming language and ordered by descending populatrity (number of stars).*
 
 
 ## Backtesting and Live Trading
@@ -252,6 +252,7 @@ Method and caveats are written up on [the wiki](https://paperswithbacktest.com/w
 | [Investpy](https://github.com/alvarobartt/investpy) | Financial Data Extraction from Investing.com with Python | ![GitHub stars](https://badgen.net/github/stars/alvarobartt/investpy) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Fundamental Analysis Data](https://github.com/JerBouma/FundamentalAnalysis) | Fully-fledged Fundamental Analysis package capable of collecting 20 years of Company Profiles, Financial Statements, Ratios and Stock Data of 20.000+ companies. | ![GitHub stars](https://badgen.net/github/stars/JerBouma/FundamentalAnalysis) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Wallstreet](https://github.com/mcdallas/wallstreet) `dormant since 2024-07` | Wallstreet: Real time Stock and Option tools | ![GitHub stars](https://badgen.net/github/stars/mcdallas/wallstreet) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
+| [pwb-toolbox](https://github.com/paperswithbacktest/pwb-toolbox) | Loader for the 32 Papers With Backtest datasets on Hugging Face: daily prices back to 1962 for stocks, ETFs, indices, currencies and commodities, sovereign yield curves, quarterly fundamentals, FRED-MD macro series, and 5.7 billion rows of 1-minute US equity bars. Cards and schemas are open to read, downloads are gated. | ![GitHub stars](https://badgen.net/github/stars/paperswithbacktest/pwb-toolbox) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 
 
 ### Cryptocurrencies

--- a/README_ja.md
+++ b/README_ja.md
@@ -13,7 +13,7 @@
 
 ### ここで見つかるもの
 
-- リサーチとライブトレーディング向けの [102のライブラリ・パッケージ](#ライブラリとパッケージ)。停止済み・休止中のプロジェクトには印を付けています
+- リサーチとライブトレーディング向けの [103のライブラリ・パッケージ](#ライブラリとパッケージ)。停止済み・休止中のプロジェクトには印を付けています
 - 公開論文からの [戦略](#戦略)。コード化して実行したときに出たシャープレシオ付き
 - 初心者からプロ向けの [55冊の書籍](#書籍)
 - [22本の動画](#動画) とインタビュー
@@ -100,7 +100,7 @@
 
 # ライブラリとパッケージ
 
-_トレーディングボット、バックテスター、インジケーター、プライサーなどを実装した **102のライブラリ・パッケージ** のリストです。各ライブラリはプログラミング言語ごとに分類され、人気順（スター数の降順）に並んでいます。_
+_トレーディングボット、バックテスター、インジケーター、プライサーなどを実装した **103のライブラリ・パッケージ** のリストです。各ライブラリはプログラミング言語ごとに分類され、人気順（スター数の降順）に並んでいます。_
 
 ## バックテストとライブトレーディング
 
@@ -236,6 +236,7 @@ _金融メトリクスのライブラリ。_
 | [Investpy](https://github.com/alvarobartt/investpy)                          | PythonでInvesting.comから金融データを抽出。                                                                                    | ![GitHub stars](https://badgen.net/github/stars/alvarobartt/investpy)          | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Fundamental Analysis Data](https://github.com/JerBouma/FundamentalAnalysis) | 2万社以上の企業プロフィール・財務諸表・財務比率・株価データを20年分収集できるファンダメンタル分析パッケージ。                  | ![GitHub stars](https://badgen.net/github/stars/JerBouma/FundamentalAnalysis)  | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Wallstreet](https://github.com/mcdallas/wallstreet)                         | Wallstreet：リアルタイム株式・オプションツール。                                                                               | ![GitHub stars](https://badgen.net/github/stars/mcdallas/wallstreet)           | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
+| [pwb-toolbox](https://github.com/paperswithbacktest/pwb-toolbox) | Hugging Face 上の Papers With Backtest データセット 32 件のローダー。株式・ETF・指数・通貨・コモディティの 1962 年からの日次価格、国債イールドカーブ、四半期財務諸表、FRED-MD マクロ系列、そして米国株の1 分足 57 億行。カードとスキーマは誰でも読めますが、ダウンロードには承認が必要です。 | ![GitHub stars](https://badgen.net/github/stars/paperswithbacktest/pwb-toolbox) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 
 ### 暗号通貨
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -12,7 +12,7 @@
 <!-- omit in toc -->
 ### 你在这里会发现什么？
 
-- [107 个](#库和包)用于研究和实际交易的[库和包](#库和包)，已失效和停止维护的项目都作了标注
+- [108 个](#库和包)用于研究和实际交易的[库和包](#库和包)，已失效和停止维护的项目都作了标注
 - 来自已发表论文的[策略](#策略)，附上每一个被编码运行后实测的夏普比率
 - [55本](#书籍)适合初学者和专业人士的[书籍](#书籍)
 - [22个视频](#视频)和采访
@@ -89,7 +89,7 @@
 
 # 库和包
 
-*107个实现交易机器人、回溯测试器、指标、定价器等的库和包列表。每个库都按其编程语言分类，并按人口降序排列（星星的数量）。*
+*108个实现交易机器人、回溯测试器、指标、定价器等的库和包列表。每个库都按其编程语言分类，并按人口降序排列（星星的数量）。*
 
 
 ## 回溯测试和真实交易
@@ -239,6 +239,7 @@
 | [Investpy](https://github.com/alvarobartt/investpy) | 用Python从Investing.com提取金融数据 | ![GitHub stars](https://badgen.net/github/stars/alvarobartt/investpy) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Fundamental Analysis Data](https://github.com/JerBouma/FundamentalAnalysis) | 完整的基本面分析软件包能够收集20年的公司简介、财务报表、比率和20,000多家公司的股票数据。 | ![GitHub stars](https://badgen.net/github/stars/JerBouma/FundamentalAnalysis) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Wallstreet](https://github.com/mcdallas/wallstreet) | 华尔街。实时股票和期权工具 | ![GitHub stars](https://badgen.net/github/stars/mcdallas/wallstreet) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
+| [pwb-toolbox](https://github.com/paperswithbacktest/pwb-toolbox) | Hugging Face 上 32 个 Papers With Backtest 数据集的加载器：股票、ETF、指数、外汇和大宗商品自 1962 年起的日频价格，主权收益率曲线，季度财务报表，FRED-MD 宏观序列，以及 57 亿行美股分钟级数据。数据卡和字段说明公开可读，下载需要授权。 | ![GitHub stars](https://badgen.net/github/stars/paperswithbacktest/pwb-toolbox) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 
 
 


### PR DESCRIPTION
Stacked on #94, so that the section counters stay right as the entry lands. Merge that one first, or retarget this at `main` and run `python scripts/update_counts.py` after.

The list runs a Strategies section built from replications, and had no entry for the data those replications are run on.

## Why the loader and not the datasets

The entry points at [`pwb-toolbox`](https://github.com/paperswithbacktest/pwb-toolbox) rather than at `huggingface.co/paperswithbacktest` or `paperswithbacktest.com/datasets`. Every one of the 111 other entries in this section links to a repository you can read and run, and ten pull requests were closed this week for pointing at a hosted service instead. A self-entry should not be the exception to a rule its own maintainer just applied to other people.

## The number, stated rather than glossed

`pwb-toolbox` has **76 stars**, MIT, last pushed 2026-08-02. That is below the **183** of this section's tenth percentile, and above everything closed this week, which topped out at 60. The two closest comparables merged today sit at **84** (QTradeX) and **79** (ml-quant-trading). Reviewers should know it is the maintainer's own project entering slightly under the line.

## The description

> Loader for the 32 Papers With Backtest datasets on Hugging Face: daily prices back to 1962 for stocks, ETFs, indices, currencies and commodities, sovereign yield curves, quarterly fundamentals, FRED-MD macro series, and 5.7 billion rows of 1-minute US equity bars. Cards and schemas are open to read, downloads are gated.

Every figure is measured off the parquet files: 32 public datasets, `Stocks-Daily-Price` starting 1962-01-02, `Stocks-1Min-Price` at 5,710,703,934 rows. "Sovereign yield curves" rather than bond prices, because `Bonds-Daily-Price` carries rates in percent, not prices. The gating is said out loud, since a data source a reader cannot fetch is worth flagging before they click.

Added to `README.md`, `README_zh.md` and `README_ja.md` together.