### PR TITLE
Stop the monthly check failing on a label that was never created

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -40,7 +40,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh issue create \
-            --title "Maintenance: dead entries or stale counters ($(date +%Y-%m))" \
-            --body-file report.txt \
-            --label maintenance
+          # The label has to exist before it can be applied. A run that found
+          # something must not fail over the label, so it is created first and
+          # the issue is opened without it if that still goes wrong: the report
+          # is the point, not the taxonomy.
+          title="Maintenance: dead entries or stale counters ($(date +%Y-%m))"
+          gh label create maintenance \
+            --color 0e8a16 \
+            --description "Housekeeping surfaced by the monthly checks" \
+            --force || true
+          gh issue create --title "$title" --body-file report.txt --label maintenance \
+            || gh issue create --title "$title" --body-file report.txt


### PR DESCRIPTION
The first scheduled run of the monthly check ([run #1](https://github.com/paperswithbacktest/awesome-systematic-trading/actions)) failed with:

```
could not add label: 'maintenance' not found
Error: Process completed with exit code 1.
```

I referenced a `maintenance` label in the workflow in #93 without creating it. The repository only had GitHub's nine default labels, so `gh issue create --label maintenance` failed and took the step down with it.

**The report was computed and then thrown away.** Both checks ran fine: the counters were up to date, and the link check correctly returned 1 because there are dead and archived entries. That is the whole point of the job, and nobody was told.

## Fix

The `maintenance` label now exists in the repository. The workflow also creates it itself with `--force`, so a fork or a restored repository does not hit the same wall, and falls back to opening the issue with no label if that somehow still fails. A run that found something has to be able to say so; the label is secondary.

## What the run would have reported

For the record, from running both checks locally against `main`:

- Counters: up to date. It does print the standing gap between the translations, `README.md 111, README_zh.md 107, README_ja.md 102`, without failing on it.
- Links: 9 dead or archived entries and 27 dormant ones, which is why the exit code was 1.

Worth dispatching the workflow by hand once this lands, to confirm the issue actually opens.