### PR TITLE
Report the monthly check in the run summary instead of a new issue

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   check:
@@ -27,7 +26,7 @@ jobs:
           echo "status=$?" >> "$GITHUB_OUTPUT"
           cat report.txt
       # The counters drift as entries are merged one pull request at a time, so
-      # they are checked on the same schedule and reported in the same issue.
+      # they are checked on the same schedule and reported in the same report.
       - name: Check the section counters
         id: counts
         run: |
@@ -35,19 +34,20 @@ jobs:
           python scripts/update_counts.py --check >> report.txt 2>&1
           echo "status=$?" >> "$GITHUB_OUTPUT"
           tail -n 20 report.txt
-      - name: Open an issue when entries are dead or counters are stale
-        if: steps.check.outputs.status == '1' || steps.counts.outputs.status == '1'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # The report goes to the run summary rather than to a new issue every
+      # month: the findings are the same list of dormant projects until someone
+      # prunes them, and a fresh issue per run only buries the human ones.
+      - name: Report dead entries and stale counters
+        if: always()
         run: |
-          # The label has to exist before it can be applied. A run that found
-          # something must not fail over the label, so it is created first and
-          # the issue is opened without it if that still goes wrong: the report
-          # is the point, not the taxonomy.
-          title="Maintenance: dead entries or stale counters ($(date +%Y-%m))"
-          gh label create maintenance \
-            --color 0e8a16 \
-            --description "Housekeeping surfaced by the monthly checks" \
-            --force || true
-          gh issue create --title "$title" --body-file report.txt --label maintenance \
-            || gh issue create --title "$title" --body-file report.txt
+          {
+            echo "## Link and count check"
+            echo
+            echo '```'
+            cat report.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.check.outputs.status }}" = '1' ] || [ "${{ steps.counts.outputs.status }}" = '1' ]; then
+            echo "::error::Dead entries or stale counters, see the run summary"
+            exit 1
+          fi


### PR DESCRIPTION
The scheduled `Link and count check` opened a fresh issue on every run that found something. It finds the same things every month until someone prunes the dormant entries, so the tracker filled with byte-identical duplicates (#98 and #101 were the same report a month apart) that buried the human-filed issues.

## Changes

- Dropped the `gh issue create` step from `.github/workflows/link-check.yml`.
- The concatenated report now goes to `$GITHUB_STEP_SUMMARY`, fenced, and the job exits 1 when either check failed — which is what GitHub already notifies watchers about for scheduled workflows.
- Removed `issues: write` from the workflow permissions, leaving only `contents: read`.

The two check steps are unchanged, so the signal is identical; only the delivery moved. The `maintenance` label and its `gh label create --force` call go away with the issue step.

## Verification

- The workflow YAML parses and the reporting step resolves as expected.
- `python scripts/update_counts.py --check` still exits 0 and reports the language mismatch (`README.md` 112, `README_zh.md` 108, `README_ja.md` 103).
- `scripts/check_links.py` was not run here — it makes ~113 GitHub API calls — and is untouched by this change.

Note that the findings themselves are still outstanding: 9 dead or archived entries, 27 dormant, and the three READMEs disagree on the library count. This PR only changes where that report is delivered, not the work it describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6AQyW8RhYWgTV6iZehxx2

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6AQyW8RhYWgTV6iZehxx2)_