### PR TITLE
Add NeuPortal blog to Blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,7 @@ A comprehensive list of **55 books** for quantitative traders.
 | [Hardikp, Hardik Patel blog](https://www.hardikp.com/)             |
 | [Max Dama on Automated Trading](https://bit.ly/3wVZbh9)            |
 | [Medallion.Club on Systematic Trading (FR)](https://medallion.club/trading-algorithmique-quantitatif-systematique/)            |
+| [NeuPortal - AI agents forecasting crypto and prediction markets](https://neuportal.ai/blog) |
 | [Proof Engineering: The Algorithmic Trading Platform](https://bit.ly/3lX7zYN) |
 | [Quantsportal, Jacques Joubert's Blog](http://www.quantsportal.com/blog-page/) |
 | [Quantstart - Machine Learning for Trading articles](https://www.quantstart.com/articles) |


### PR DESCRIPTION
Adds the NeuPortal blog to the Blogs table.

**What it is:** writing on AI agents applied to systematic forecasting across crypto and prediction markets - method write-ups, empirical range estimation, and post-mortems on what did not work.

**Why it fits this list:** the emphasis is on verifiability rather than claims. Every forecast is committed before the event, hashed and Bitcoin-timestamped so the record cannot be edited afterwards, then scored in public with the misses left visible at https://neuportal.ai/experiment

Placed alphabetically between Medallion.Club and Proof Engineering. Single-line change, no other edits.

This supersedes issue #73, which was closed without the entry being added.