### PR TITLE
Add Manifold-BT to Vector Based Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 <!-- omit in toc -->
 ### What will you find here?
 
-- [136 libraries and packages](#libraries-and-packages) for research and live trading, with dead and dormant projects flagged
+- [137 libraries and packages](#libraries-and-packages) for research and live trading, with dead and dormant projects flagged
 - [Strategies](#strategies) from published papers, with the Sharpe ratio each one produced when it was coded and run
 - [55 books](#books) for beginners and professionals
 - [22 videos](#videos) and interviews
@@ -100,7 +100,7 @@ Method and caveats are written up on [the wiki](https://paperswithbacktest.com/w
 
 # Libraries and packages
 
-*List of **136 libraries and packages** implementing trading bots, backtesters, indicators, pricers, etc. Each library is categorized by its programming language and ordered by descending populatrity (number of stars).*
+*List of **137 libraries and packages** implementing trading bots, backtesters, indicators, pricers, etc. Each library is categorized by its programming language and ordered by descending populatrity (number of stars).*
 
 
 ## Backtesting and Live Trading
@@ -145,6 +145,7 @@ Method and caveats are written up on [the wiki](https://paperswithbacktest.com/w
 |------------|-------------|-------|-----------|
 | [QTradeX](https://github.com/squidKid-deluxe/QTradeX-Algo-Trading-SDK) | A powerful and flexible Python framework for designing, backtesting, optimizing, and deploying algotrading bots | ![GitHub stars](https://badgen.net/github/stars/squidKid-deluxe/QTradeX-Algo-Trading-SDK) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [vectorbt](https://github.com/polakowo/vectorbt) | vectorbt takes a novel approach to backtesting: it operates entirely on pandas and NumPy objects, and is accelerated by Numba to analyze any data at speed and scale. This allows for testing of many thousands of strategies in seconds. | ![GitHub stars](https://badgen.net/github/stars/polakowo/vectorbt) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
+| [Manifold-BT](https://github.com/manifoldbt/manifoldbt) | High-performance Rust-powered Python backtesting engine: vectorized signal expressions with realistic per-bar fills (fees, slippage, look-ahead), parameter sweeps, walk-forward and Monte Carlo. | ![GitHub stars](https://badgen.net/github/stars/manifoldbt/manifoldbt) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [pysystemtrade](https://github.com/robcarver17/pysystemtrade) | Systematic Trading in python from book Systematic Trading by Rob Carver | ![GitHub stars](https://badgen.net/github/stars/robcarver17/pysystemtrade) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [bt](https://github.com/pmorissette/bt) | Flexible backtesting for Python based on Algo and Strategy Tree | ![GitHub stars](https://badgen.net/github/stars/pmorissette/bt) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [ml-quant-trading](https://github.com/initial-d/ml-quant-trading) | PyTorch research stack for ML multi-factor trading with 213 factors, bias correction, portfolio optimization, vectorized backtesting, and public validation reports | ![GitHub stars](https://badgen.net/github/stars/initial-d/ml-quant-trading) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |


### PR DESCRIPTION
Adds Manifold-BT to Backtesting and Live Trading → General - Vector Based Frameworks (alongside vectorbt).

- Rust-powered engine with a Python API (`pip install manifoldbt`).
- Vectorized signal expressions + realistic per-bar fills (fees, slippage, look-ahead).
- Parameter sweeps, walk-forward, and Monte Carlo.
- Active project with docs and runnable examples at https://www.manifoldbt.com

Also bumps the libraries count from 136 to 137.

Not archived, not a duplicate of an existing entry.